### PR TITLE
Avoid erroneous "Post without data"

### DIFF
--- a/apache/apache/apache.fec
+++ b/apache/apache/apache.fec
@@ -40,6 +40,10 @@ module-header
 
 }
 
+namespace Apache {
+	object request;
+}
+
 /**
  * @class Request
  * @brief This class provides an interface to apache. 
@@ -652,7 +656,10 @@ class Request
 	* @return A Request object which can then be used to gleam valuable information.
 	*/
 	static function current() {
-		return new Request();
+		if ( ! Apache.request ) {
+			Apache.request = new Request();
+		}
+		return Apache.request;
 	}
 }
 /**


### PR DESCRIPTION
Apache.fec's current() unconditionally creates a new request object. If
it is called twice for the same request then it this will trigger a
reread of the already read post data which leads to the error
"mode_ferite: Post without data".

Use the singleton design pattern to ensure that only one instance of the
request object is created per request.
